### PR TITLE
Add comprehensive tests for prompt processing

### DIFF
--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -273,3 +273,48 @@ def test_nested_parameter_permutations(cli):
     for prompt in data:
         assert prompt["text"] == "smooth edges"
         assert (prompt.get("personalization"), prompt["stylize"]) in variants
+
+
+def test_mj_command(cli):
+    """Test Midjourney prompt conversion."""
+    with StringIO() as capture_stdout:
+        sys.stdout = capture_stdout
+        cli.mj("a serene landscape --ar 16:9 --stylize 100", json_output=True)
+        sys.stdout = sys.__stdout__
+        data = parse_json_output(capture_stdout)
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["text"] == "a serene landscape"
+    assert data[0]["aspect"] == "16:9"
+    assert data[0]["stylize"] == 100
+
+
+def test_fal_command(cli):
+    """Test Fal.ai prompt conversion."""
+    with StringIO() as capture_stdout:
+        sys.stdout = capture_stdout
+        cli.fal("a serene landscape --ar 16:9 --stylize 100", json_output=True)
+        sys.stdout = sys.__stdout__
+        data = parse_json_output(capture_stdout)
+    assert isinstance(data, dict)
+    assert data["prompt"] == "a serene landscape"
+    assert data["aspect_ratio"] == "16:9"
+    assert data["stylize"] == 100
+
+
+def test_perm_command(cli):
+    """Test permutation expansion."""
+    with StringIO() as capture_stdout:
+        sys.stdout = capture_stdout
+        cli.perm("a {red, blue} bird on a {branch, rock}", json_output=True)
+        sys.stdout = sys.__stdout__
+        data = parse_json_output(capture_stdout)
+    assert isinstance(data, list)
+    assert len(data) == 4
+    expected = [
+        "a red bird on a branch",
+        "a red bird on a rock",
+        "a blue bird on a branch",
+        "a blue bird on a rock",
+    ]
+    assert set(data) == set(expected)

--- a/tests/core/test_input.py
+++ b/tests/core/test_input.py
@@ -82,3 +82,39 @@ def test_whitespace_handling():
     assert len(result) == PERMUTATION_COUNT_2
     assert "a red bird" in result
     assert "a blue bird" in result
+
+
+def test_expand_midjargon_input():
+    """Test expand_midjargon_input function to verify prompt expansion."""
+    result = expand_midjargon_input("a {red, blue} bird")
+    assert len(result) == 2
+    assert "a red bird" in result
+    assert "a blue bird" in result
+
+    result = expand_midjargon_input("a {red, blue, green} bird")
+    assert len(result) == 3
+    assert "a red bird" in result
+    assert "a blue bird" in result
+    assert "a green bird" in result
+
+    result = expand_midjargon_input("a {red {cat, dog}, blue bird}")
+    assert len(result) == 3
+    assert "a red cat" in result
+    assert "a red dog" in result
+    assert "a blue bird" in result
+
+
+def test_handling_escaped_characters():
+    """Test handling of escaped characters in expand_midjargon_input."""
+    result = expand_midjargon_input(r"a \{red, blue\} bird")
+    assert len(result) == 1
+    assert result[0] == "a {red, blue} bird"
+
+    result = expand_midjargon_input(r"a {red\, blue, green} bird")
+    assert len(result) == 2
+    assert "a red, blue bird" in result
+    assert "a green bird" in result
+
+    result = expand_midjargon_input(r"a {red, blue\} bird")
+    assert len(result) == 1
+    assert result[0] == "a {red, blue} bird"

--- a/tests/core/test_parameters.py
+++ b/tests/core/test_parameters.py
@@ -120,3 +120,102 @@ def test_invalid_parameters():
 
     with pytest.raises(ValueError, match="Missing value for parameter"):
         parse_parameters("--v")  # Missing version value
+
+
+def test_parse_parameters():
+    """Test parse_parameters function to verify parameter parsing."""
+    param_str = "--ar 16:9 --stylize 100"
+    params = parse_parameters(param_str)
+    assert params["aspect"] == "16:9"
+    assert params["stylize"] == "100"
+
+    param_str = "--tile --turbo --relax"
+    params = parse_parameters(param_str)
+    assert params["tile"] is None
+    assert params["turbo"] is None
+    assert params["relax"] is None
+
+    param_str = "--no blur,cars,watermark"
+    params = parse_parameters(param_str)
+    assert params["no"] == "blur,cars,watermark"
+
+    param_str = '--style "raw photo" --seed 123456'
+    params = parse_parameters(param_str)
+    assert params["style"] == "raw photo"
+    assert params["seed"] == "123456"
+
+    param_str = '--ar 16:9 --tile --no blur,cars --style "raw photo"'
+    params = parse_parameters(param_str)
+    assert params["aspect"] == "16:9"
+    assert params["tile"] is None
+    assert params["no"] == "blur,cars"
+    assert params["style"] == "raw photo"
+
+    param_str = "--s 100 --c 50 --w 1000 --iw 2.0 --q 1.0"
+    params = parse_parameters(param_str)
+    assert params["stylize"] == "100"
+    assert params["chaos"] == "50"
+    assert params["weird"] == "1000"
+    assert params["image_weight"] == "2.0"
+    assert params["quality"] == "1.0"
+
+    params = parse_parameters("--niji")
+    assert params["version"] == "niji"
+
+    params = parse_parameters("--niji 6")
+    assert params["version"] == "niji 6"
+
+    params = parse_parameters("--v 5.2")
+    assert params["version"] == "5.2"
+
+    params = parse_parameters("--p")
+    assert params["personalization"] is None  # Flag without value is None
+
+    params = parse_parameters("--p custom")
+    assert params["personalization"] == "custom"
+
+    params = parse_parameters("--personalization custom")
+    assert params["personalization"] == "custom"
+
+    param_str = "--cref img1.jpg --sref style1.jpg,style2.jpg"
+    params = parse_parameters(param_str)
+    assert params["character_reference"] == "img1.jpg"
+    assert params["style_reference"] == "style1.jpg,style2.jpg"
+
+    param_str = "--seed 123 --ar 16:9 --chaos 20 --tile"
+    params = parse_parameters(param_str)
+    keys = list(params.keys())
+    assert keys == ["seed", "aspect", "chaos", "tile"]
+
+    with pytest.raises(ValueError, match="Empty parameter name"):
+        parse_parameters("--")  # Empty parameter name
+
+    with pytest.raises(ValueError, match="Missing value for parameter"):
+        parse_parameters("--ar")  # Missing required value
+
+    with pytest.raises(ValueError, match="Parameter name cannot start with dash"):
+        parse_parameters("ar 16:9")  # Missing -- prefix
+
+    with pytest.raises(ValueError, match="Missing value for parameter"):
+        parse_parameters("--v")  # Missing version value
+
+
+def test_flag_parameters_handling():
+    """Test handling of flag parameters in parse_parameters."""
+    param_str = "--tile --turbo --relax"
+    params = parse_parameters(param_str)
+    assert params["tile"] is None
+    assert params["turbo"] is None
+    assert params["relax"] is None
+
+    param_str = "--p"
+    params = parse_parameters(param_str)
+    assert params["personalization"] is None  # Flag without value is None
+
+    param_str = "--p custom"
+    params = parse_parameters(param_str)
+    assert params["personalization"] == "custom"
+
+    param_str = "--personalization custom"
+    params = parse_parameters(param_str)
+    assert params["personalization"] == "custom"

--- a/tests/core/test_parser.py
+++ b/tests/core/test_parser.py
@@ -1,0 +1,94 @@
+"""Tests for prompt parsing functionality."""
+
+from midjargon.core.parser import parse_midjargon_prompt_to_dict
+
+# Test constants
+ASPECT_RATIO = "16:9"
+STYLIZE_VALUE = 100
+CHAOS_VALUE = 50
+IMAGE_URL = "https://example.com/image.jpg"
+
+
+def test_basic_prompt_parsing():
+    """Test basic prompt parsing."""
+    prompt = "a beautiful landscape --ar 16:9 --stylize 100"
+    result = parse_midjargon_prompt_to_dict(prompt)
+    assert result["text"] == "a beautiful landscape"
+    assert result["aspect"] == ASPECT_RATIO
+    assert result["stylize"] == STYLIZE_VALUE
+
+
+def test_prompt_with_image_url():
+    """Test prompt parsing with image URL."""
+    prompt = f"{IMAGE_URL} a mystical forest --chaos 50"
+    result = parse_midjargon_prompt_to_dict(prompt)
+    assert result["text"] == "a mystical forest"
+    assert result["images"] == [IMAGE_URL]
+    assert result["chaos"] == CHAOS_VALUE
+
+
+def test_prompt_with_multiple_image_urls():
+    """Test prompt parsing with multiple image URLs."""
+    image_urls = [
+        "https://example.com/image1.jpg",
+        "https://example.com/image2.jpg",
+    ]
+    prompt = f"{image_urls[0]} {image_urls[1]} a serene landscape --stylize 100"
+    result = parse_midjargon_prompt_to_dict(prompt)
+    assert result["text"] == "a serene landscape"
+    assert result["images"] == image_urls
+    assert result["stylize"] == STYLIZE_VALUE
+
+
+def test_prompt_with_parameters():
+    """Test prompt parsing with various parameters."""
+    prompt = "a futuristic city --ar 16:9 --stylize 100 --chaos 50"
+    result = parse_midjargon_prompt_to_dict(prompt)
+    assert result["text"] == "a futuristic city"
+    assert result["aspect"] == ASPECT_RATIO
+    assert result["stylize"] == STYLIZE_VALUE
+    assert result["chaos"] == CHAOS_VALUE
+
+
+def test_prompt_with_empty_parameters():
+    """Test prompt parsing with empty parameters."""
+    prompt = "a landscape photo --tile --no blur,cars"
+    result = parse_midjargon_prompt_to_dict(prompt)
+    assert result["text"] == "a landscape photo"
+    assert result["tile"] is None
+    assert result["no"] == "blur,cars"
+
+
+def test_prompt_with_escaped_characters():
+    """Test prompt parsing with escaped characters."""
+    prompt = r"a \{red, blue\} bird"
+    result = parse_midjargon_prompt_to_dict(prompt)
+    assert result["text"] == r"a {red, blue} bird"
+
+
+def test_prompt_with_nested_permutations():
+    """Test prompt parsing with nested permutations."""
+    prompt = "a {big {red, blue}, small green} bird"
+    result = parse_midjargon_prompt_to_dict(prompt)
+    assert result["text"] == "a {big {red, blue}, small green} bird"
+
+
+def test_prompt_with_unmatched_braces():
+    """Test prompt parsing with unmatched braces."""
+    prompt = "a {red, blue bird"
+    result = parse_midjargon_prompt_to_dict(prompt)
+    assert result["text"] == "a {red, blue bird"
+
+
+def test_prompt_with_empty_permutation():
+    """Test prompt parsing with empty permutation options."""
+    prompt = "a {} bird"
+    result = parse_midjargon_prompt_to_dict(prompt)
+    assert result["text"] == "a bird"
+
+
+def test_prompt_with_whitespace_handling():
+    """Test prompt parsing with various whitespace patterns."""
+    prompt = "a {  red  ,  blue  } bird"
+    result = parse_midjargon_prompt_to_dict(prompt)
+    assert result["text"] == "a {  red  ,  blue  } bird"

--- a/tests/engines/midjourney/test_parser.py
+++ b/tests/engines/midjourney/test_parser.py
@@ -396,3 +396,44 @@ def test_new_parameter_validation():
     # Test invalid repeat value
     with pytest.raises(ValueError, match=r"Invalid numeric value for repeat: 200"):
         parser.parse_dict({"text": "a photo", "repeat": "200"})
+
+
+def test_edge_cases():
+    """Test handling of edge cases in Midjourney parser."""
+    parser = MidjourneyParser()
+
+    # Test empty prompt
+    with pytest.raises(ValueError, match="Empty prompt"):
+        parser.parse_dict({"text": ""})
+
+    # Test prompt with only spaces
+    with pytest.raises(ValueError, match="Empty prompt"):
+        parser.parse_dict({"text": "   "})
+
+    # Test prompt with special characters
+    prompt = parser.parse_dict({"text": "a photo with special characters !@#$%^&*()"})
+    assert prompt.text == "a photo with special characters !@#$%^&*()"
+
+    # Test prompt with long text
+    long_text = "a" * 1000
+    prompt = parser.parse_dict({"text": long_text})
+    assert prompt.text == long_text
+
+    # Test prompt with mixed types in extra parameters
+    prompt = parser.parse_dict(
+        {
+            "text": "a photo",
+            "extra1": 123,
+            "extra2": 45.67,
+            "extra3": True,
+            "extra4": None,
+            "extra5": ["item1", "item2"],
+        }
+    )
+    assert prompt.extra_params == {
+        "extra1": "123",
+        "extra2": "45.67",
+        "extra3": "True",
+        "extra4": None,
+        "extra5": ["item1", "item2"],
+    }

--- a/tests/integration/test_workflow.py
+++ b/tests/integration/test_workflow.py
@@ -4,6 +4,7 @@ import pytest
 
 from midjargon import expand_midjargon_input, parse_midjargon_prompt_to_dict
 from midjargon.engines.midjourney import MidjourneyPrompt, parse_midjourney_dict
+from midjargon.cli.main import MidjargonCLI
 
 # Test constants
 ASPECT_WIDTH = 16
@@ -278,3 +279,42 @@ def test_permutations_with_complex_parameters():
     }
 
     assert result_tuples == expected
+
+
+def test_cli_mj_command():
+    """Test Midjourney prompt conversion using CLI."""
+    cli = MidjargonCLI()
+    prompt = "a serene landscape --ar 16:9 --stylize 100"
+    results = cli.mj(prompt, json_output=True)
+    assert isinstance(results, list)
+    assert len(results) == 1
+    assert results[0]["text"] == "a serene landscape"
+    assert results[0]["aspect"] == "16:9"
+    assert results[0]["stylize"] == 100
+
+
+def test_cli_fal_command():
+    """Test Fal.ai prompt conversion using CLI."""
+    cli = MidjargonCLI()
+    prompt = "a serene landscape --ar 16:9 --stylize 100"
+    results = cli.fal(prompt, json_output=True)
+    assert isinstance(results, dict)
+    assert results["prompt"] == "a serene landscape"
+    assert results["aspect_ratio"] == "16:9"
+    assert results["stylize"] == 100
+
+
+def test_cli_perm_command():
+    """Test permutation expansion using CLI."""
+    cli = MidjargonCLI()
+    prompt = "a {red, blue} bird on a {branch, rock}"
+    results = cli.perm(prompt, json_output=True)
+    assert isinstance(results, list)
+    assert len(results) == 4
+    expected = [
+        "a red bird on a branch",
+        "a red bird on a rock",
+        "a blue bird on a branch",
+        "a blue bird on a rock",
+    ]
+    assert set(results) == set(expected)


### PR DESCRIPTION
### **User description**
---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/twardoch/midjargon/pull/2?shareId=a366734f-ba69-4541-8a74-b8dfefb1751b).


___

### **PR Type**
Tests


___

### **Description**
- Added comprehensive unit tests for CLI commands (`mj`, `fal`, `perm`).

- Enhanced core functionality tests for prompt parsing and parameter handling.

- Introduced edge case tests for Midjourney parser and prompt parsing.

- Added integration tests for CLI workflow and prompt processing.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_main.py</strong><dd><code>Add CLI command tests for prompt processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/cli/test_main.py

<li>Added tests for <code>mj</code>, <code>fal</code>, and <code>perm</code> CLI commands.<br> <li> Verified JSON output and prompt parsing correctness.<br> <li> Ensured proper handling of permutations and parameters.


</details>


  </td>
  <td><a href="https://github.com/twardoch/midjargon/pull/2/files#diff-ca8ba482572f6ca569313a0c0035af634c06a455fe9125cfd0a3e0f124c96a46">+45/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_input.py</strong><dd><code>Add tests for input expansion and edge cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/core/test_input.py

<li>Added tests for <code>expand_midjargon_input</code> function.<br> <li> Verified handling of escaped characters and nested permutations.<br> <li> Ensured proper expansion of prompts with various patterns.


</details>


  </td>
  <td><a href="https://github.com/twardoch/midjargon/pull/2/files#diff-45bfb511805af5fb600c307e9bdfe6de0cff0229b4dd0b42e0caa13e0c821605">+36/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_parameters.py</strong><dd><code>Add parameter parsing tests with error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/core/test_parameters.py

<li>Added tests for <code>parse_parameters</code> function.<br> <li> Verified handling of flags, missing values, and complex parameters.<br> <li> Ensured proper error handling for invalid inputs.


</details>


  </td>
  <td><a href="https://github.com/twardoch/midjargon/pull/2/files#diff-fede19847ca395934366d4a82693348349e3a93fe97b6af0f72d7ebb0d3cf84c">+99/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_parser.py</strong><dd><code>Add tests for prompt parsing functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/core/test_parser.py

<li>Introduced tests for <code>parse_midjargon_prompt_to_dict</code>.<br> <li> Verified parsing of prompts with images, parameters, and edge cases.<br> <li> Ensured proper handling of nested permutations and unmatched braces.


</details>


  </td>
  <td><a href="https://github.com/twardoch/midjargon/pull/2/files#diff-f611b347be1b2358c96cba95ef7479f5ef4a3d8e937ac8cf642944f213a562c4">+94/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_parser.py</strong><dd><code>Add edge case tests for Midjourney parser</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/engines/midjourney/test_parser.py

<li>Added edge case tests for Midjourney parser.<br> <li> Verified handling of empty prompts and special characters.<br> <li> Ensured proper parsing of mixed-type extra parameters.


</details>


  </td>
  <td><a href="https://github.com/twardoch/midjargon/pull/2/files#diff-5c9bf394b8faa22ede95c6a3a16f48b752bcc6b3a520ea6362fe6361e81411ec">+41/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_workflow.py</strong><dd><code>Add integration tests for CLI workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/integration/test_workflow.py

<li>Added integration tests for CLI commands (<code>mj</code>, <code>fal</code>, <code>perm</code>).<br> <li> Verified end-to-end workflow for prompt processing.<br> <li> Ensured proper output and parameter handling in CLI.


</details>


  </td>
  <td><a href="https://github.com/twardoch/midjargon/pull/2/files#diff-db0dc2919254b08e3deb9bc3d1ab54da5d0e3da50599678701010805b3d17dac">+40/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>